### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/Poojan0201/66a028e4-42f3-4901-93bf-e2d8e47af6b2/be306522-3fa6-40f0-addb-07b17884344f/_apis/work/boardbadge/dd51a1f8-03b3-4708-9570-02465c518d98)](https://dev.azure.com/Poojan0201/66a028e4-42f3-4901-93bf-e2d8e47af6b2/_boards/board/t/be306522-3fa6-40f0-addb-07b17884344f/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Poojan0201/66a028e4-42f3-4901-93bf-e2d8e47af6b2/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.